### PR TITLE
Add safety for handling unstaked deposits that still exist in the user deposit array

### DIFF
--- a/src/actions/getAllDeposits.ts
+++ b/src/actions/getAllDeposits.ts
@@ -1,11 +1,11 @@
 import { ethers } from "ethers";
 import { getCorePool } from "../helpers";
-import { SubConfig, Deposit, MappedDeposit } from "../types";
+import { SubConfig, Deposit } from "../types";
 
 export const getAllDeposits = async (
   address: string,
   config: SubConfig
-): Promise<MappedDeposit[]> => {
+): Promise<Deposit[]> => {
   if (!ethers.utils.isAddress(address))
     throw Error("Must provide a valid user address");
 
@@ -15,7 +15,7 @@ export const getAllDeposits = async (
 
   if (depositLength.eq(ethers.BigNumber.from("0"))) return [];
 
-  const deposits: MappedDeposit[] = [];
+  const deposits: Deposit[] = [];
 
   for (let i = 0; i < depositLength.toNumber(); i++) {
     const deposit = await corePool.getDeposit(

--- a/src/actions/unstake.ts
+++ b/src/actions/unstake.ts
@@ -19,7 +19,7 @@ export const unstake = async (
   if (depositsLength.eq(ethers.BigNumber.from(0)))
     throw Error("There are no deposits for you to unstake");
 
-  const deposit: Deposit = await corePool.getDeposit(address, depositId);
+  const deposit = await corePool.getDeposit(address, depositId);
   if (ethers.BigNumber.from(amount).gt(deposit.tokenAmount))
     throw Error("You cannot unstake more than the original stake amount");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,15 +54,12 @@ export interface PoolInstance {
 }
 
 export interface Deposit {
+  depositId: number;
   tokenAmount: BigNumber;
   weight: BigNumber;
   lockedFrom: BigNumber;
   lockedUntil: BigNumber;
   isYield: boolean;
-}
-
-export interface MappedDeposit extends Deposit {
-  depositId: number;
 }
 
 // Intentionally ignore the Deposit[] prop associated with a user


### PR DESCRIPTION
When a user calls to `unstake`, their `Deposits[]` on chain is modified to delete this storage reference, but in translation to TypeScript this reference still exists and is just set to 0 value. To manage this, we need to be able to filter 0 value deposits out from when serving `getAllDeposits` to a consumer