### PR TITLE
Update Apr function to return as percent not multiplier value

### DIFF
--- a/src/actions/calculatePoolApr.ts
+++ b/src/actions/calculatePoolApr.ts
@@ -59,9 +59,9 @@ export const calculatePoolApr = async (
   if (!isLpTokenPool) {
     const balance = await pool.poolTokenReserve();
     const apr =
-      (rewardsInNextYear / Number(ethers.utils.formatUnits(balance, 18))) *
+      (rewardsInNextYear / Number(ethers.utils.formatUnits(balance, 18))) * 
       weightRatio;
-    return apr;
+    return apr * 100; // as percentage
   }
 
   const client = new CoinGecko();
@@ -111,5 +111,5 @@ export const calculatePoolApr = async (
 
   const lpTokenPoolApr =
     ((rewardsInNextYear * wildPriceUsd) / lpTokenPoolTvl) * weightRatio;
-  return lpTokenPoolApr;
+  return lpTokenPoolApr * 100; // as percentage
 };


### PR DESCRIPTION
We can calculate APR for a pool if we know the amount of rewards in a year as well as the balance of that pool.

Let's say we have `1000` rewards in a year with `250` currently staked in the pool, we get

`1000 / 250 = 4`

`4` is the multiplier we *would* return from this function, but it should be `400` because we are showing as a percentage.

This small change of ` * 100` to the ending value adds that