### PR TITLE
Updates for LP token and fix for calling to calculate APR and TVL

### DIFF
--- a/src/actions/calculatePoolTotalValueLocked.ts
+++ b/src/actions/calculatePoolTotalValueLocked.ts
@@ -1,5 +1,5 @@
 import * as ethers from "ethers";
-import { SubConfig, TotalValueLocked } from "../types";
+import { NetworkChainId, SubConfig, TotalValueLocked } from "../types";
 import { ZStakeCorePool } from "../contracts";
 import { getCorePool } from "../helpers";
 import {
@@ -15,20 +15,12 @@ export const calculatePoolTotalValueLocked = async (
 ): Promise<TotalValueLocked> => {
   let addresses;
   const network = await config.provider.getNetwork();
-  switch (network.chainId) {
-    case 1:
-      addresses = networkAddresses.mainnet;
-      break;
-    case 42:
-      addresses = networkAddresses.kovan;
-    default:
-      addresses = networkAddresses.kovan;
-      break;
-  }
+  const chainId: NetworkChainId = network.chainId;
+  addresses = networkAddresses[chainId];
 
   if (!addresses)
     throw Error(
-      "No addresses could be inferred from the network. Use mainnet or kovan"
+      "No addresses could be inferred from the network. Use mainnet, rinkeby, or kovan"
     );
 
   const pool: ZStakeCorePool = await getCorePool(config);

--- a/src/actions/helpers/index.ts
+++ b/src/actions/helpers/index.ts
@@ -1,5 +1,6 @@
 import CoinGecko from "coingecko-api";
 import * as ethers from "ethers";
+import { NetworkChainId } from "../../types";
 
 const erc20Abi = [
   "function balanceOf(address _owner) public view returns (uint256)",
@@ -7,33 +8,39 @@ const erc20Abi = [
 ];
 
 export const networkAddresses = {
-  mainnet: {
+  1: { // mainnet
     WILD: "0x2a3bFF78B79A009976EeA096a51A948a3dC00e34",
     wETH: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
     wildStakingPool: "0x3aC551725ac98C5DCdeA197cEaaE7cDb8a71a2B4",
     lpTokenStakingPool: "0x9E87a268D42B0Aba399C121428fcE2c626Ea01FF",
     factory: "0xF133faFd49f4671ac63EE3a3aE7E7C4C9B84cE4a",
-    UniswapPool: "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5",
+    UniswapPoolToken: "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5",
   },
-  kovan: {
+  42: { // kovan
     WILD: "0x50A0A3E9873D7e7d306299a75Dc05bd3Ab2d251F",
     wETH: "0x61659a8093FeAe3be9E1fb1B410e8E3C6de38894", // Mock wETH
     wildStakingPool: "0x4E226a8BbECAa435d2c77D3E4a096F87322Ef1Ae",
     lpTokenStakingPool: "0x9CF0DaD38E4182d944a1A4463c56CFD1e6fa8fE7",
     factory: "0x47946797E05A34B47ffE7151D0Fbc15E8297650E",
-    UniswapPool: "0xD364C50c33902110230255FE1D730D84FA23e48e",
+    UniswapPoolToken: "0xD364C50c33902110230255FE1D730D84FA23e48e",
   },
+  4: { // rinkeby
+    WILD: "0x3Ae5d499cfb8FB645708CC6DA599C90e64b33A79",
+    wETH: "0x5bAbCA2Af93A9887C86161083b8A90160DA068f2", // Actually mLOOT
+    wildStakingPool: "0xE0Bb298Afc5dC12918d02732c824DA44e7D61E2a",
+    lpTokenStakingPool: "0xe7BEeedAf11eE695C4aE64A01b24F3F7eA294aB6",
+    factory: "0xb1d051095B6b2f6C93198Cbaa9bb7cB2d607215C",
+    UniswapPoolToken: "0x0A0f5AD73077108cFD806a0de77333AdA928cC99",
+  }
 };
 
 export const getWildToken = async (
-  provider: ethers.providers.Provider
+  provider: ethers.providers.Provider,
 ): Promise<ethers.Contract> => {
   const network = await provider.getNetwork();
-  let address =
-    network.chainId === 1
-      ? networkAddresses.mainnet.WILD
-      : networkAddresses.kovan.WILD;
+  const chainId: NetworkChainId = network.chainId;
 
+  const address = networkAddresses[chainId].WILD
   const wildToken = new ethers.Contract(address, erc20Abi, provider);
 
   return wildToken;
@@ -43,10 +50,8 @@ export const getWethToken = async (
   provider: ethers.providers.Provider
 ): Promise<ethers.Contract> => {
   const network = await provider.getNetwork();
-  const address =
-    network.chainId === 1
-      ? networkAddresses.mainnet.wETH
-      : networkAddresses.kovan.wETH;
+  const chainId: NetworkChainId = network.chainId;
+  const address = networkAddresses[chainId].wETH
 
   const wEthToken = new ethers.Contract(address, erc20Abi, provider);
 
@@ -57,13 +62,10 @@ export const getLpToken = async (
   provider: ethers.providers.Provider
 ): Promise<ethers.Contract> => {
   const network = await provider.getNetwork();
-  const address =
-    network.chainId === 1
-      ? networkAddresses.mainnet.UniswapPool
-      : networkAddresses.kovan.UniswapPool;
+  const chainId: NetworkChainId = network.chainId;
+  const address = networkAddresses[chainId].UniswapPoolToken;
 
   const lpToken = new ethers.Contract(address, erc20Abi, provider);
-
   return lpToken;
 };
 
@@ -87,10 +89,8 @@ export const ethPriceUsd = async () => {
 
 export const lpTokenPriceUsd = async (provider: ethers.providers.Provider) => {
   const network = await provider.getNetwork();
-  const uniswapPool =
-    network.chainId === 1
-      ? networkAddresses.mainnet.UniswapPool
-      : networkAddresses.kovan.UniswapPool;
+  const chainId: NetworkChainId = network.chainId;
+  const uniswapPoolAddress = networkAddresses[chainId].UniswapPoolToken;
 
   let tokenPromises = [
     getLpToken(provider),
@@ -108,8 +108,8 @@ export const lpTokenPriceUsd = async (provider: ethers.providers.Provider) => {
   // Because we use Function Fragments internally, these return `any` types if nt
   // explicitly defined
   let balancePromises = [
-    wildToken.balanceOf(uniswapPool) as ethers.BigNumber,
-    wethToken.balanceOf(uniswapPool) as ethers.BigNumber,
+    wildToken.balanceOf(uniswapPoolAddress) as ethers.BigNumber,
+    wethToken.balanceOf(uniswapPoolAddress) as ethers.BigNumber,
     lpToken.totalSupply() as ethers.BigNumber,
   ];
 

--- a/src/actions/stake.ts
+++ b/src/actions/stake.ts
@@ -13,6 +13,8 @@ export const stake = async (
 
   const corePool = await getCorePool(config);
   const stakeAmount = ethers.BigNumber.from(amount);
-  const tx = await corePool.connect(signer).stake(stakeAmount, lockUntil);
+  const tx = await corePool
+    .connect(signer)
+    .stake(stakeAmount, lockUntil);
   return tx;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,8 +145,9 @@ const getFactoryInstance = (config: SubConfig) => {
       return poolAddress;
     },
     getPoolData: async (poolTokenAddress: string): Promise<PoolData> => {
-      if (!ethers.utils.isAddress(poolTokenAddress))
+      if (!ethers.utils.isAddress(poolTokenAddress)) {
         throw Error("Cannot get pool data for empty pool address");
+      }
       const factory = await getPoolFactory(config);
       const poolData: PoolData = await factory.getPoolData(poolTokenAddress);
       return poolData;

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,12 @@ export interface Deposit {
   isYield: boolean;
 }
 
+export enum NetworkChainId {
+  mainnet = 1,
+  rinkeby = 4,
+  kovan = 42,
+}
+
 // Intentionally ignore the Deposit[] prop associated with a user
 // we can get that information directly with `getAllDeposits`
 export interface User {

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -18,9 +18,9 @@ dotenv.config();
 describe("Test Custom SDK Logic", () => {
   const config: Config = {
     provider: new ethers.providers.JsonRpcProvider(process.env["INFURA_URL"], 42),
-    factoryAddress: "0x47946797E05A34B47ffE7151D0Fbc15E8297650E",
-    lpTokenPoolAddress: "0x9CF0DaD38E4182d944a1A4463c56CFD1e6fa8fE7",
-    wildPoolAddress: "0x4E226a8BbECAa435d2c77D3E4a096F87322Ef1Ae",
+    factoryAddress: "0xb1d051095B6b2f6C93198Cbaa9bb7cB2d607215C",
+    lpTokenPoolAddress: "0xe7BEeedAf11eE695C4aE64A01b24F3F7eA294aB6",
+    wildPoolAddress: "0xE0Bb298Afc5dC12918d02732c824DA44e7D61E2a",
   };
 
   // Dummy address pulled from Ethers VoidSigner docs

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,0 +1,69 @@
+/// <reference path="../node_modules/@types/mocha/index.d.ts" />
+
+import * as chai from "chai";
+import * as chaiAsPromised from "chai-as-promised";
+import * as ethers from "ethers";
+import * as dotenv from "dotenv";
+import { ImportMock } from "ts-mock-imports";
+
+import { Config, Deposit, SubConfig } from "../src/types";
+import * as helpers from "../src/helpers";
+import { createInstance } from "../src";
+
+chai.use(chaiAsPromised.default);
+const expect = chai.expect;
+dotenv.config();
+
+describe("Test Custom SDK Logic", () => {
+  const provider = new ethers.providers.StaticJsonRpcProvider(
+    process.env.INFURA_URL,
+    4
+  );
+  it("Runs a full scenario through the SDK", async () => {
+    const config: Config = {
+      wildPoolAddress: "0xE0Bb298Afc5dC12918d02732c824DA44e7D61E2a",
+      lpTokenPoolAddress: "0xe7BEeedAf11eE695C4aE64A01b24F3F7eA294aB6",
+      factoryAddress: "0xb1d051095B6b2f6C93198Cbaa9bb7cB2d607215C",
+      provider: provider,
+    };
+
+
+
+    const sdk = createInstance(config);
+
+    const poolApr = await sdk.wildPool.poolApr();
+    console.log(poolApr);
+
+    const poolTvl = await sdk.wildPool.poolTvl();
+    console.log(poolTvl);
+
+    const lpPoolApr = await sdk.liquidityPool.poolApr();
+    console.log(lpPoolApr)
+
+    const factory = await helpers.getPoolFactory({
+      address: config.factoryAddress,
+      provider,
+    });
+
+    const tw = await factory.totalWeight();
+    console.log(tw);
+
+    const pk = process.env.TESTNET_PRIVATE_KEY;
+    if (!pk) throw Error("no key");
+    const wallet = new ethers.Wallet(pk, provider);
+
+    try {
+      const tx = await sdk.wildPool.stake(
+        ethers.utils.parseEther("12.4").toString(),
+        ethers.BigNumber.from("10441982"),
+        wallet
+      );
+
+      console.log(tx.hash);
+      const receipt = await tx.wait(1);
+      console.log(receipt);
+    } catch (e) {
+      console.log(e);
+    }
+  });
+});

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -4,7 +4,6 @@ import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised";
 import * as ethers from "ethers";
 import * as dotenv from "dotenv";
-import { ImportMock } from "ts-mock-imports";
 
 import { Config, Deposit, SubConfig } from "../src/types";
 import * as helpers from "../src/helpers";
@@ -27,9 +26,10 @@ describe("Test Custom SDK Logic", () => {
       provider: provider,
     };
 
-
-
     const sdk = createInstance(config);
+    const token = await sdk.wildPool.getPoolToken();
+    const data = await sdk.factory.getPoolData(token);
+    console.log(data);
 
     const poolApr = await sdk.wildPool.poolApr();
     console.log(poolApr);


### PR DESCRIPTION
Was failing because the incorrect address was being given for the LP token, so `totalSupply()` would cause errors in the dapp. This fixes that, and actually uses an LP token on Uniswap rinkeby  by creating a mock wild and mock loot pair.

Also as a side effect fixes the `getPoolData` issue that was happening

https://rinkeby.etherscan.io/tx/0x96b2939de1c959f8cfd1162d41e68860f39be2bafb8a7e0c5716100501715a39

